### PR TITLE
fix semi-broken links to API docs

### DIFF
--- a/src/1.3.4/core/advanced/json_bean_definitions.md
+++ b/src/1.3.4/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.3.4/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.4/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.3.5/core/advanced/json_bean_definitions.md
+++ b/src/1.3.5/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.3.5/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.5/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.3.6/core/advanced/json_bean_definitions.md
+++ b/src/1.3.6/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.3.6/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.6/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.3.7/core/advanced/json_bean_definitions.md
+++ b/src/1.3.7/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.3.7/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.7/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.4.1/core/advanced/json_bean_definitions.md
+++ b/src/1.4.1/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.4.1/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.1/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.4.2/core/advanced/json_bean_definitions.md
+++ b/src/1.4.2/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.4.2/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.2/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/1.4.3/core/advanced/json_bean_definitions.md
+++ b/src/1.4.3/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/1.4.3/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.3/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).

--- a/src/latest/core/advanced/json_bean_definitions.md
+++ b/src/latest/core/advanced/json_bean_definitions.md
@@ -37,7 +37,7 @@ There are two categories of built-in types (click on the links to learn more abo
 * **complex types**: [Object](http://ariatemplates.com/api/#aria.core.JsonTypes:Object), [Array](http://ariatemplates.com/api/#aria.core.JsonTypes:Array), [Map](http://ariatemplates.com/api/#aria.core.JsonTypes:Map), [MultiTypes](http://ariatemplates.com/api/#aria.core.JsonTypes:MultiTypes)
 
 
-When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/##aria.core.BaseTypes:Element)):
+When creating your bean definition, you can always include the following properties (an explanation is also available [here](http://ariatemplates.com/api/#aria.core.BaseTypes:Element)):
 
 * **`$type`:** the mandatory parent type
 * **`$description`:** a short literal description of your data type. It is mandatory when inheriting directly from a built-in data type. When inheriting from a user-defined schema, it is not necessarily required.
@@ -110,4 +110,4 @@ As you can see in the previous code snippet, bean definitions allow you to assoc
 
 ## Bean definitions inside classes
 
-It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/##aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.
+It is also possible to specify class-specific bean definitions inside the `$beans` key of the [classDefintion configuration Json object](http://ariatemplates.com/api/#aria.core.CfgBeans:ClassDefinitionCfg). However, the schemas thus defined cannot be used in any way at the moment.

--- a/src/latest/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/latest/core/concepts/working_in_an_asynchronous_world.md
@@ -94,4 +94,4 @@ Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 
-The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/##aria.core.CfgBeans:IOAsyncRequestCfg).
+The whole list of configuration parameters is available in [Async Request](http://ariatemplates.com/api/#aria.core.CfgBeans:IOAsyncRequestCfg).


### PR DESCRIPTION
Links have double # in URLs which kills the browser's back button in Chrome upon
clicking them.
