### PR TITLE
TOC improvements

### DIFF
--- a/resources/articles/layout.jade
+++ b/resources/articles/layout.jade
@@ -82,7 +82,7 @@ html(lang='en')
                                                 mixin category(cat)
                                 if metadata && metadata.Navbar
                                     nav.navigationbar
-                                        div#dropdown.aligncenter.nav-main
+                                        div#dropdown.aligncenter.nav-main(tabindex="0")
                                             mixin includeNavBar(metadata.version)
                                     mixin doc()
 
@@ -144,6 +144,9 @@ html(lang='en')
                             li: a(href='/about/team') The Team
             section.content.legal &copy; 2012 Aria Templates is licensed under Apache 2.0 license. See our
                 a(href='/license') licensing page
+
+        script(type='text/javascript')
+            document.querySelector && document.querySelector("a[href='" + document.URL.slice(document.URL.lastIndexOf('/')+1) + "']").className += " currentURL";
 
         script(type='text/javascript')
             var _gaq = _gaq || [];

--- a/resources/documentation.css
+++ b/resources/documentation.css
@@ -330,7 +330,7 @@ body.internal article .callout.reviewed,
 	font-weight: bold;
 }
 
-.menu-container li.son {
+.menu-container li.son > a {
 	padding-left: 15px;
 }
 
@@ -349,11 +349,15 @@ body.internal article .callout.reviewed,
 	100% { opacity: 1; -ms-animation-timing-function: linear; display:block; }
 }
 
-#dropdown:hover {
+#dropdown:hover,
+#dropdown:focus,
+#dropdown:active {
 	background: #333;
 }
 
-#dropdown:hover .menu-container {
+#dropdown:hover .menu-container,
+#dropdown:focus .menu-container,
+#dropdown:active .menu-container {
 	display: block;
 	opacity: 1;
 	/*
@@ -373,6 +377,17 @@ body.internal article .callout.reviewed,
 	display:inline;
 	float:left;
 	position:relative;
+}
+
+.column-1 a,.column-2 a {
+	display:block;
+}
+
+a.currentURL {
+	color: #A2D8FA;
+}
+a.currentURL:hover {
+	color: #000;
 }
 
 .column-1 li:hover,.column-2 li:hover {


### PR DESCRIPTION
1) Highlight current file in the dropdown
2) Make dropdown expand also from keyboard
3) Display links in TOC as block so they get 100% width

Ad 1, I've made it with inline javascript at the end of the file but this is rather a hack, would be better to do this in jade at build time, but my eyes bleed when I read Jade templates (and yes, I'm a noob too :P)
So, before integrating, should be checked if this doesn't break IE etc., or to rewrite it as a build-time thing.

Ad 2, dropdown can be expanded from keyboard, but the items on the list are not TAB-navigable, which actually might be a good thing (getting through 50 links before having the real content reachable can be boring). However, when the dropdown is made visible via tabbing, AND one clicks some non-TAB button then, then the items from the list are accessible via subsequently tabbing (the issue is that the dropdown appears only on  `:active` of a parent, and the TAB-order is probably evaluated beforehand).
