### PR TITLE
Rest API: formatting

### DIFF
--- a/src/1.3.4/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.4/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.3.5/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.5/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.3.6/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.6/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.3.7/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.3.7/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.1/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.1/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.10/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.10/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.2/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.2/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.3/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.3/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.4/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.4/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.5/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.5/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.6/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.6/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.7/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.7/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.8/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.8/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/1.4.9/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/1.4.9/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 

--- a/src/latest/core/concepts/working_in_an_asynchronous_world.md
+++ b/src/latest/core/concepts/working_in_an_asynchronous_world.md
@@ -90,7 +90,7 @@ And don't forget to execute it when the async job is over using `this.$callback(
 
 ## Rest API calls
 
-Aria Templates allows users to make `GET`, `POST`,`PUT`,`DELETE`,`HEAD`,`TRACE`,`OPTIONS`,`CONNECT`,`PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
+Aria Templates allows users to make `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `TRACE`, `OPTIONS`, `CONNECT`, `PATCH` requests to a Restful server. The default method will be `GET` if request method is not defined. The following snippet demonstrates how to make an asynchronous request in Aria Templates.
 
 <script src='http://snippets.ariatemplates.com/snippets/github.com/ariatemplates/documentation-code/snippets/core/asynchronous/Async.js?tag=sampleAsyncRequest&lang=javascript&outdent=true' defer></script>
 


### PR DESCRIPTION
Word wrapping is awful in zoomed-text mode in Firefox due to lack of spaces.
