### PR TITLE
Sidebar dropdown now remembers the article

### DIFF
--- a/resources/articles/versionList.jade
+++ b/resources/articles/versionList.jade
@@ -12,7 +12,7 @@ mixin version(version, latest)
 
 h4 Documentation Version
 div.styled-select
-  select(onchange='document.location = "/usermanual/" + this.options[this.selectedIndex].value + "/"')
+  select(onchange='document.location = "/usermanual/" + this.options[this.selectedIndex].value + document.URL.match(/\\\/[^\\\/]*$/)')
     mixin version("1.4.13", true)
     mixin version("1.4.12")
     mixin version("1.4.11")


### PR DESCRIPTION
See #21.

Code review remark:
the final JS string that lands in the HTML file is 
`document.URL.match(/\/[^\/]*$/)`
Seems that Jade processor does some stripping hence in the jade file it's needed to escape the backslashes:
`document.URL.match(/\\\/[^\\\/]*$/)`

This works fine both on usermanual index page (which is `/usermanual/<version>/`) and articles (which are `/usermanual/<version>/foo-bar`). 
