### PR TITLE
Revert NODE_ENV usage in snippet server url replacement

### DIFF
--- a/resources/articles/layout.jade
+++ b/resources/articles/layout.jade
@@ -1,7 +1,7 @@
 -metadata.version = whoAmI.split(/usermanual[\\\/]src[\\\/]/)[1].split(/[\\\/]/)[0]
 -metadata.Navbar = (metadata.Navbar ? (metadata.Navbar === 'false' ? false: true ) : true)
 -metadata.Toc = (metadata.Toc ? (metadata.Toc === 'false' ? false: true ) : true)
--urlSnippet = (process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'http://snippets.ariatemplates.com')
+-urlSnippet = (process.env.NODE_ENV === 'production' ? 'http://snippets.ariatemplates.com' : 'http://localhost:3000')
 
 mixin doc
     div.doc(class=(metadata.CssClass||""))


### PR DESCRIPTION
Reverting node_env usage to be 'development' the default
