### PR TITLE
Fix follow-the-scroll misbehaving on low browser width

### DIFF
--- a/resources/follow-the-scroll-menu.js
+++ b/resources/follow-the-scroll-menu.js
@@ -107,7 +107,7 @@
                 if (elem) {
                     elem.style.color = null;
                     elem.style.color = "navy";
-                    if (!isFullyVisible(elem)) {
+                    if (!isFullyVisible(elem) && document.documentElement.clientWidth > 1000) {
                         elem.scrollIntoView();
                     }
                 }


### PR DESCRIPTION
When browser width was small, the right-side menu was taking over
the focus after every scroll, hiding the real contents - that could be
reproduced e.g. in Chrome or IE mobile.
