### PR TITLE
Allow different repository folder names

### DIFF
--- a/resources/articles/layout.jade
+++ b/resources/articles/layout.jade
@@ -1,4 +1,4 @@
--metadata.version = whoAmI.split(/usermanual[\\\/]src[\\\/]/)[1].split(/[\\\/]/)[0]
+-metadata.version = whoAmI.split(/[^\\\/]*[\\\/]src[\\\/]/)[1].split(/[\\\/]/)[0]
 -metadata.Navbar = (metadata.Navbar ? (metadata.Navbar === 'false' ? false: true ) : true)
 -metadata.Toc = (metadata.Toc ? (metadata.Toc === 'false' ? false: true ) : true)
 -urlSnippet = (process.env.NODE_ENV === 'production' ? 'http://snippets.ariatemplates.com' : 'http://localhost:3000')


### PR DESCRIPTION
This commit fixes the execution of the `start` script from a repository whose folder name is different from `usermanual`.
